### PR TITLE
fix: correct argument order for mergeApiOptions calls

### DIFF
--- a/src/sdk/qf/audio.ts
+++ b/src/sdk/qf/audio.ts
@@ -44,7 +44,7 @@ const findAllChapterRecitations = async (
   reciterId: string,
   options?: GetChapterRecitationOptions
 ) => {
-  const params = mergeApiOptions(options, defaultChapterRecitationsOptions);
+  const params = mergeApiOptions(defaultChapterRecitationsOptions, options);
   const { audioFiles } = await fetcher<{ audioFiles: ChapterRecitation[] }>(
     `/chapter_recitations/${reciterId}`,
     params,
@@ -69,7 +69,7 @@ const findChapterRecitationById = async (
 ) => {
   if (!Utils.isValidChapterId(chapterId)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultChapterRecitationsOptions);
+  const params = mergeApiOptions(defaultChapterRecitationsOptions, options);
   const { audioFile } = await fetcher<{ audioFile: ChapterRecitation }>(
     `/chapter_recitations/${reciterId}/${chapterId}`,
     params,
@@ -95,7 +95,7 @@ const findVerseRecitationsByChapter = async (
 ) => {
   if (!Utils.isValidChapterId(chapterId)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -124,7 +124,7 @@ const findVerseRecitationsByJuz = async (
 ) => {
   if (!Utils.isValidJuz(juz)) throw new Error('Invalid juz');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -149,7 +149,7 @@ const findVerseRecitationsByPage = async (
 ) => {
   if (!Utils.isValidQuranPage(page)) throw new Error('Invalid page');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -174,7 +174,7 @@ const findVerseRecitationsByRub = async (
 ) => {
   if (!Utils.isValidRub(rub)) throw new Error('Invalid rub');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -199,7 +199,7 @@ const findVerseRecitationsByHizb = async (
 ) => {
   if (!Utils.isValidHizb(hizb)) throw new Error('Invalid hizb');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -224,7 +224,7 @@ const findVerseRecitationsByKey = async (
 ) => {
   if (!Utils.isValidVerseKey(key)) throw new Error('Invalid verse key');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;

--- a/src/sdk/qf/chapters.ts
+++ b/src/sdk/qf/chapters.ts
@@ -18,7 +18,7 @@ const defaultOptions: GetChapterOptions = {
  * quran.v4.chapters.findAll()
  */
 const findAll = async (options?: GetChapterOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapters } = await fetcher<{ chapters: Chapter[] }>(
     '/chapters',
     params,
@@ -40,7 +40,7 @@ const findAll = async (options?: GetChapterOptions) => {
 const findById = async (id: ChapterId, options?: GetChapterOptions) => {
   if (!Utils.isValidChapterId(id)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapter } = await fetcher<{ chapter: Chapter }>(
     `/chapters/${id}`,
     params,
@@ -62,7 +62,7 @@ const findById = async (id: ChapterId, options?: GetChapterOptions) => {
 const findInfoById = async (id: ChapterId, options?: GetChapterOptions) => {
   if (!Utils.isValidChapterId(id)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapterInfo } = await fetcher<{ chapterInfo: ChapterInfo }>(
     `/chapters/${id}/info`,
     params,

--- a/src/sdk/qf/resources.ts
+++ b/src/sdk/qf/resources.ts
@@ -47,7 +47,7 @@ const findAllRecitations = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findRecitationInfo('1')
  */
 const findRecitationInfo = async (id: string, options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: RecitationInfoResource;
   }>(`/resources/recitations/${id}/info`, params, options?.fetchFn);
@@ -63,7 +63,7 @@ const findRecitationInfo = async (id: string, options?: GetResourceOptions) => {
  * quran.v4.resources.findAllTranslations()
  */
 const findAllTranslations = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { translations } = await fetcher<{
     translations: TranslationResource[];
   }>('/resources/translations', params, options?.fetchFn);
@@ -83,7 +83,7 @@ const findTranslationInfo = async (
   id: string,
   options?: GetResourceOptions
 ) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: TranslationInfoResource;
   }>(`/resources/translations/${id}/info`, params, options?.fetchFn);
@@ -99,7 +99,7 @@ const findTranslationInfo = async (
  * quran.v4.resources.findAllTafsirs()
  */
 const findAllTafsirs = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { tafsirs } = await fetcher<{
     tafsirs: TafsirResource[];
   }>('/resources/tafsirs', params, options?.fetchFn);
@@ -116,7 +116,7 @@ const findAllTafsirs = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findTafsirInfo('1')
  */
 const findTafsirInfo = async (id: string, options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: TafsirInfoResource;
   }>(`/resources/tafsirs/${id}/info`, params, options?.fetchFn);
@@ -148,7 +148,7 @@ const findAllRecitationStyles = async (
  * quran.v4.resources.findAllLanguages()
  */
 const findAllLanguages = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { languages } = await fetcher<{
     languages: LanguageResource[];
   }>('/resources/languages', params, options?.fetchFn);
@@ -164,7 +164,7 @@ const findAllLanguages = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findAllChapterInfos()
  */
 const findAllChapterInfos = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapterInfos } = await fetcher<{
     chapterInfos: ChapterInfoResource[];
   }>('/resources/chapter_infos', params, options?.fetchFn);
@@ -180,7 +180,7 @@ const findAllChapterInfos = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findVerseMedia()
  */
 const findVerseMedia = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { verseMedia } = await fetcher<{
     verseMedia: VerseMediaResource;
   }>(`/resources/verse_media`, params, options?.fetchFn);
@@ -196,7 +196,7 @@ const findVerseMedia = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findAllChapterReciters()
  */
 const findAllChapterReciters = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { reciters } = await fetcher<{
     reciters: Reciter[];
   }>(`/resources/chapter_reciters`, params, options?.fetchFn);

--- a/src/sdk/qf/search.ts
+++ b/src/sdk/qf/search.ts
@@ -28,7 +28,7 @@ const defaultSearchOptions: SearchOptions = {
  */
 const search = async (q: string, options?: SearchOptions) => {
 
-  const params = mergeApiOptions({ q, ...options }, defaultSearchOptions);
+  const params = mergeApiOptions(defaultSearchOptions, { q, ...options });
 
   const { search } = await fetcher<SearchResponse>(
     '/search',

--- a/src/sdk/qf/verses.ts
+++ b/src/sdk/qf/verses.ts
@@ -41,7 +41,7 @@ const defaultOptions: GetVerseOptions = {
 };
 
 const mergeVerseOptions = (options: GetVerseOptions = {}) => {
-  const result = mergeApiOptions(options, defaultOptions);
+  const result = mergeApiOptions(defaultOptions, options);
 
   // @ts-expect-error - we accept an array of strings, however, the API expects a comma separated string
   if (result.translations) result.translations = result.translations.join(',');

--- a/src/sdk/v4/audio.ts
+++ b/src/sdk/v4/audio.ts
@@ -43,7 +43,7 @@ const findAllChapterRecitations = async (
   reciterId: string,
   options?: GetChapterRecitationOptions
 ) => {
-  const params = mergeApiOptions(options, defaultChapterRecitationsOptions);
+  const params = mergeApiOptions(defaultChapterRecitationsOptions, options);
   const { audioFiles } = await fetcher<{ audioFiles: ChapterRecitation[] }>(
     `/chapter_recitations/${reciterId}`,
     params,
@@ -68,7 +68,7 @@ const findChapterRecitationById = async (
 ) => {
   if (!Utils.isValidChapterId(chapterId)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultChapterRecitationsOptions);
+  const params = mergeApiOptions(defaultChapterRecitationsOptions, options);
   const { audioFile } = await fetcher<{ audioFile: ChapterRecitation }>(
     `/chapter_recitations/${reciterId}/${chapterId}`,
     params,
@@ -94,7 +94,7 @@ const findVerseRecitationsByChapter = async (
 ) => {
   if (!Utils.isValidChapterId(chapterId)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -123,7 +123,7 @@ const findVerseRecitationsByJuz = async (
 ) => {
   if (!Utils.isValidJuz(juz)) throw new Error('Invalid juz');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -148,7 +148,7 @@ const findVerseRecitationsByPage = async (
 ) => {
   if (!Utils.isValidQuranPage(page)) throw new Error('Invalid page');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -173,7 +173,7 @@ const findVerseRecitationsByRub = async (
 ) => {
   if (!Utils.isValidRub(rub)) throw new Error('Invalid rub');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -198,7 +198,7 @@ const findVerseRecitationsByHizb = async (
 ) => {
   if (!Utils.isValidHizb(hizb)) throw new Error('Invalid hizb');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;
@@ -223,7 +223,7 @@ const findVerseRecitationsByKey = async (
 ) => {
   if (!Utils.isValidVerseKey(key)) throw new Error('Invalid verse key');
 
-  const params = mergeApiOptions(options, defaultVerseRecitationsOptions);
+  const params = mergeApiOptions(defaultVerseRecitationsOptions, options);
   const data = await fetcher<{
     audioFiles: VerseRecitation[];
     pagination: Pagination;

--- a/src/sdk/v4/chapters.ts
+++ b/src/sdk/v4/chapters.ts
@@ -17,7 +17,7 @@ const defaultOptions: GetChapterOptions = {
  * quran.v4.chapters.findAll()
  */
 const findAll = async (options?: GetChapterOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapters } = await fetcher<{ chapters: Chapter[] }>(
     '/chapters',
     params,
@@ -39,7 +39,7 @@ const findAll = async (options?: GetChapterOptions) => {
 const findById = async (id: ChapterId, options?: GetChapterOptions) => {
   if (!Utils.isValidChapterId(id)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapter } = await fetcher<{ chapter: Chapter }>(
     `/chapters/${id}`,
     params,
@@ -61,7 +61,7 @@ const findById = async (id: ChapterId, options?: GetChapterOptions) => {
 const findInfoById = async (id: ChapterId, options?: GetChapterOptions) => {
   if (!Utils.isValidChapterId(id)) throw new Error('Invalid chapter id');
 
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapterInfo } = await fetcher<{ chapterInfo: ChapterInfo }>(
     `/chapters/${id}/info`,
     params,

--- a/src/sdk/v4/resources.ts
+++ b/src/sdk/v4/resources.ts
@@ -46,7 +46,7 @@ const findAllRecitations = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findRecitationInfo('1')
  */
 const findRecitationInfo = async (id: string, options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: RecitationInfoResource;
   }>(`/resources/recitations/${id}/info`, params, options?.fetchFn);
@@ -62,7 +62,7 @@ const findRecitationInfo = async (id: string, options?: GetResourceOptions) => {
  * quran.v4.resources.findAllTranslations()
  */
 const findAllTranslations = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { translations } = await fetcher<{
     translations: TranslationResource[];
   }>('/resources/translations', params, options?.fetchFn);
@@ -82,7 +82,7 @@ const findTranslationInfo = async (
   id: string,
   options?: GetResourceOptions
 ) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: TranslationInfoResource;
   }>(`/resources/translations/${id}/info`, params, options?.fetchFn);
@@ -98,7 +98,7 @@ const findTranslationInfo = async (
  * quran.v4.resources.findAllTafsirs()
  */
 const findAllTafsirs = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { tafsirs } = await fetcher<{
     tafsirs: TafsirResource[];
   }>('/resources/tafsirs', params, options?.fetchFn);
@@ -115,7 +115,7 @@ const findAllTafsirs = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findTafsirInfo('1')
  */
 const findTafsirInfo = async (id: string, options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { info } = await fetcher<{
     info: TafsirInfoResource;
   }>(`/resources/tafsirs/${id}/info`, params, options?.fetchFn);
@@ -147,7 +147,7 @@ const findAllRecitationStyles = async (
  * quran.v4.resources.findAllLanguages()
  */
 const findAllLanguages = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { languages } = await fetcher<{
     languages: LanguageResource[];
   }>('/resources/languages', params, options?.fetchFn);
@@ -163,7 +163,7 @@ const findAllLanguages = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findAllChapterInfos()
  */
 const findAllChapterInfos = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { chapterInfos } = await fetcher<{
     chapterInfos: ChapterInfoResource[];
   }>('/resources/chapter_infos', params, options?.fetchFn);
@@ -179,7 +179,7 @@ const findAllChapterInfos = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findVerseMedia()
  */
 const findVerseMedia = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { verseMedia } = await fetcher<{
     verseMedia: VerseMediaResource;
   }>(`/resources/verse_media`, params, options?.fetchFn);
@@ -195,7 +195,7 @@ const findVerseMedia = async (options?: GetResourceOptions) => {
  * quran.v4.resources.findAllChapterReciters()
  */
 const findAllChapterReciters = async (options?: GetResourceOptions) => {
-  const params = mergeApiOptions(options, defaultOptions);
+  const params = mergeApiOptions(defaultOptions, options);
   const { reciters } = await fetcher<{
     reciters: ChapterReciterResource[];
   }>(`/resources/chapter_reciters`, params, options?.fetchFn);

--- a/src/sdk/v4/search.ts
+++ b/src/sdk/v4/search.ts
@@ -26,7 +26,7 @@ const defaultSearchOptions: SearchOptions = {
  * quran.v4.search.search('نور', { language: Language.ENGLISH, page: 2 })
  */
 const search = async (q: string, options?: SearchOptions) => {
-  const params = mergeApiOptions({ q, ...options }, defaultSearchOptions);
+  const params = mergeApiOptions(defaultSearchOptions, { q, ...options });
   const { search } = await fetcher<SearchResponse>(
     '/search',
     params,

--- a/src/sdk/v4/verses.ts
+++ b/src/sdk/v4/verses.ts
@@ -39,7 +39,7 @@ const defaultOptions: GetVerseOptions = {
 };
 
 const mergeVerseOptions = (options: GetVerseOptions = {}) => {
-  const result = mergeApiOptions(options, defaultOptions);
+  const result = mergeApiOptions(defaultOptions, options);
 
   // @ts-expect-error - we accept an array of strings, however, the API expects a comma separated string
   if (result.translations) result.translations = result.translations.join(',');


### PR DESCRIPTION
## Summary
- fix all mergeApiOptions call sites to pass default options first

## Testing
- `pnpm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b2be79bc832b9f76da683f597673